### PR TITLE
Missing Tofu Binary in Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ ARG TOFU_VERSION=${TOFU_VERSION:-1.6.1}
 RUN [ ${PRE_COMMIT_VERSION} = "latest" ] && pip3 install --no-cache-dir pre-commit \
     || pip3 install --no-cache-dir pre-commit==${PRE_COMMIT_VERSION}
 
-
 RUN curl -LO https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
  && curl -LO https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS \
  && [ $(sha256sum "tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip" | cut -f 1 -d ' ') = "$(grep "tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip" tofu_*_SHA256SUMS | cut -f 1 -d ' ')" ] \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,9 @@ RUN [ ${PRE_COMMIT_VERSION} = "latest" ] && pip3 install --no-cache-dir pre-comm
 RUN curl -LO https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
  && curl -LO https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS \
  && [ $(sha256sum "tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip" | cut -f 1 -d ' ') = "$(grep "tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip" tofu_*_SHA256SUMS | cut -f 1 -d ' ')" ] \
- && unzip tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
- && mv tofu /usr/bin/tofu
+ && unzip tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip -d /usr/bin/tofu \
+ && rm "tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip" \
+ && rm "tofu_${TOFU_VERSION}_SHA256SUMS"
 
 #
 # Install tools
@@ -208,6 +209,7 @@ COPY --from=builder \
     /usr/local/bin/pre-commit \
     # Hooks and terraform binaries
     /bin_dir/ \
+    /usr/bin/tofu \
     /usr/local/bin/checkov* \
         /usr/bin/
 # Copy pre-commit packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN [ ${PRE_COMMIT_VERSION} = "latest" ] && pip3 install --no-cache-dir pre-comm
 RUN curl -LO https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
  && curl -LO https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_SHA256SUMS \
  && [ $(sha256sum "tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip" | cut -f 1 -d ' ') = "$(grep "tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip" tofu_*_SHA256SUMS | cut -f 1 -d ' ')" ] \
- && unzip tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip -d /usr/bin/tofu \
+ && unzip tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip -d /usr/bin/ \
  && rm "tofu_${TOFU_VERSION}_${TARGETOS}_${TARGETARCH}.zip" \
  && rm "tofu_${TOFU_VERSION}_SHA256SUMS"
 


### PR DESCRIPTION
I encountered an issue with the tofuutils/pre-commit-opentofu Docker image. Currently, the image contains the tofu package as a ZIP file (tofu_1.6.1_linux_amd64.zip), but it does not include the extracted tofu binary, which prevents the command from running as expected.

### Details:
Image Name: tofuutils/pre-commit-opentofu
ZIP File Location: /usr/bin/tofu_1.6.1_linux_amd64.zip
Missing Binary: The extracted tofu binary is not available in the expected path.
Secreenshot of zip tofu binary:
![image](https://github.com/user-attachments/assets/4ecbd375-4349-4092-8232-3fe846b80739)
![image](https://github.com/user-attachments/assets/ff67724c-8c6e-43e4-add4-ffb230c4a550)



### Suggested Solution:
Please consider updating the Docker image to include the extracted tofu binary instead of the ZIP file. This would allow users to run the tofu command without needing to manually extract the binary.

