### PR TITLE
feat: Support .tofu files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: hooks/infracost_breakdown.sh
   language: script
   require_serial: true
-  files: \.(tf(vars)?|hcl)$
+  files: \.((tf|tofu)(vars)?|hcl)$
   exclude: \.terraform\/.*$
 
 - id: tofu_fmt
@@ -12,25 +12,29 @@
   description: Rewrites all OpenTofu configuration files to a canonical format.
   entry: hooks/tofu_fmt.sh
   language: script
-  files: (\.tf|\.tfvars)$
+  files: \.(tf|tofu)(vars)?$
   exclude: \.terraform\/.*$
 
 - id: tofu_docs
   name: OpenTofu docs
-  description: Inserts input and output documentation into README.md (using terraform-docs).
+  description:
+    Inserts input and output documentation into README.md (using
+    terraform-docs).
   require_serial: true
   entry: hooks/tofu_docs.sh
   language: script
-  files: (\.tf|\.terraform\.lock\.hcl)$
+  files: (\.(tf|tofu)|\.terraform\.lock\.hcl)$
   exclude: \.terraform\/.*$
 
 - id: tofu_docs_without_aggregate_type_defaults
   name: OpenTofu docs (without aggregate type defaults)
-  description: Inserts input and output documentation into README.md (using terraform-docs). Identical to terraform_docs.
+  description:
+    Inserts input and output documentation into README.md (using
+    terraform-docs). Identical to terraform_docs.
   require_serial: true
   entry: hooks/tofu_docs.sh
   language: script
-  files: (\.tf)$
+  files: \.(tf|tofu)$
   exclude: \.terraform\/.*$
 
 - id: tofu_docs_replace
@@ -39,7 +43,7 @@
   require_serial: true
   entry: hooks/tofu_docs_replace.py
   language: python
-  files: (\.tf)$
+  files: \.(tf|tofu)$
   exclude: \.terraform\/.*$
 
 - id: tofu_validate
@@ -48,7 +52,7 @@
   require_serial: true
   entry: hooks/tofu_validate.sh
   language: script
-  files: (\.tf|\.tfvars)$
+  files: \.(tf|tofu)(vars)?$
   exclude: \.terraform\/.*$
 
 - id: tofu_providers_lock
@@ -66,12 +70,13 @@
   require_serial: true
   entry: hooks/tofu_tflint.sh
   language: script
-  files: (\.tf|\.tfvars)$
+  files: \.(tf|tofu)(vars)?$
   exclude: \.terraform\/.*$
 
 - id: terragrunt_fmt
   name: Terragrunt fmt
-  description: Rewrites all Terragrunt configuration files to a canonical format.
+  description:
+    Rewrites all Terragrunt configuration files to a canonical format.
   entry: hooks/terragrunt_fmt.sh
   language: script
   files: (\.hcl)$
@@ -87,18 +92,20 @@
 
 - id: tofu_tfsec
   name: OpenTofu validate with tfsec (deprecated, use "tofu_trivy")
-  description: Static analysis of OpenTofu templates to spot potential security issues.
+  description:
+    Static analysis of OpenTofu templates to spot potential security issues.
   require_serial: true
   entry: hooks/tofu_tfsec.sh
-  files: \.tf(vars)?$
+  files: \.(tf|tofu)(vars)?$
   language: script
 
 - id: tofu_trivy
   name: OpenTofu validate with trivy
-  description: Static analysis of OpenTofu templates to spot potential security issues.
+  description:
+    Static analysis of OpenTofu templates to spot potential security issues.
   require_serial: true
   entry: hooks/tofu_trivy.sh
-  files: \.tf(vars)?$
+  files: \.(tf|tofu)(vars)?$
   language: script
 
 - id: checkov
@@ -118,7 +125,7 @@
   entry: hooks/tofu_checkov.sh
   language: script
   always_run: false
-  files: \.tf$
+  files: \.(tf|tofu)$
   exclude: \.terraform\/.*$
   require_serial: true
 
@@ -138,7 +145,7 @@
   description: Runs terrascan on OpenTofu templates.
   language: script
   entry: hooks/terrascan.sh
-  files: \.tf$
+  files: \.(tf|tofu)$
   exclude: \.terraform\/.*$
   require_serial: true
 
@@ -149,5 +156,5 @@
   entry: hooks/tfupdate.sh
   args:
     - --args=terraform
-  files: \.tf$
+  files: \.(tf|tofu)$
   require_serial: true

--- a/hooks/tofu_docs.sh
+++ b/hooks/tofu_docs.sh
@@ -155,7 +155,7 @@ function tofu_docs {
     #
     if $create_if_not_exist && [[ ! -f "$text_file" ]]; then
       dir_have_tf_files="$(
-        find . -maxdepth 1 -type f | sed 's|.*\.||' | sort -u | grep -oE '^tf$|^tfvars$' ||
+        find . -maxdepth 1 -type f | sed 's|.*\.||' | sort -u | grep -oE '^tofu|^tf$|^tfvars$' ||
           exit 0
       )"
 

--- a/hooks/tofu_docs_replace.py
+++ b/hooks/tofu_docs_replace.py
@@ -7,30 +7,41 @@ import sys
 def main(argv=None):
     parser = argparse.ArgumentParser(
         description="""Run terraform-docs on a set of files. Follows the standard convention of
-                       pulling the documentation from main.tf in order to replace the entire
+                       pulling the documentation from main.(tf|tofu) in order to replace the entire
                        README.md file each time."""
     )
     parser.add_argument(
-        '--dest', dest='dest', default='README.md',
+        "--dest",
+        dest="dest",
+        default="README.md",
     )
     parser.add_argument(
-        '--sort-inputs-by-required', dest='sort', action='store_true',
-        help='[deprecated] use --sort-by-required instead',
+        "--sort-inputs-by-required",
+        dest="sort",
+        action="store_true",
+        help="[deprecated] use --sort-by-required instead",
     )
     parser.add_argument(
-        '--sort-by-required', dest='sort', action='store_true',
+        "--sort-by-required",
+        dest="sort",
+        action="store_true",
     )
     parser.add_argument(
-        '--with-aggregate-type-defaults', dest='aggregate', action='store_true',
-        help='[deprecated]',
+        "--with-aggregate-type-defaults",
+        dest="aggregate",
+        action="store_true",
+        help="[deprecated]",
     )
-    parser.add_argument('filenames', nargs='*', help='Filenames to check.')
+    parser.add_argument("filenames", nargs="*", help="Filenames to check.")
     args = parser.parse_args(argv)
 
     dirs = []
     for filename in args.filenames:
-        if (os.path.realpath(filename) not in dirs and
-                (filename.endswith(".tf") or filename.endswith(".tfvars"))):
+        if os.path.realpath(filename) not in dirs and (
+            filename.endswith(".tf")
+            or filename.endswith(".tofu")
+            or filename.endswith(".tfvars")
+        ):
             dirs.append(os.path.dirname(filename))
 
     retval = 0
@@ -38,12 +49,12 @@ def main(argv=None):
     for dir in dirs:
         try:
             procArgs = []
-            procArgs.append('terraform-docs')
+            procArgs.append("terraform-docs")
             if args.sort:
-                procArgs.append('--sort-by-required')
-            procArgs.append('md')
+                procArgs.append("--sort-by-required")
+            procArgs.append("md")
             procArgs.append("./{dir}".format(dir=dir))
-            procArgs.append('>')
+            procArgs.append(">")
             procArgs.append("./{dir}/{dest}".format(dir=dir, dest=args.dest))
             subprocess.check_call(" ".join(procArgs), shell=True)
         except subprocess.CalledProcessError as e:
@@ -52,5 +63,5 @@ def main(argv=None):
     return retval
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/hooks/tofu_wrapper_module_for_each.sh
+++ b/hooks/tofu_wrapper_module_for_each.sh
@@ -312,10 +312,10 @@ EOF
 
     # Read content of all OpenTofu files
     # shellcheck disable=SC2207
-    all_tf_content=$(find "${full_module_dir}" -name '*.tf' -maxdepth 1 -type f -exec cat {} +)
+    all_tf_content=$(find "${full_module_dir}" -regex '.*\.(tf|tofu)' -maxdepth 1 -type f -exec cat {} +)
 
     if [[ ! $all_tf_content ]]; then
-      common::colorify "yellow" "Skipping ${full_module_dir} because there are no *.tf files."
+      common::colorify "yellow" "Skipping ${full_module_dir} because there are no *.(tf|tofu) files."
       continue
     fi
 


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [ ] This PR fixes a bug.
- [x] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Fixes #6 

### How can we test changes

Current behaviour:

```console 
$ git clonehttps://github.com/NorddeutscherRundfunk/opentofu-example.git
$ cd opentofu-example
$ echo "#" >> hello.tofu 
$ git add hello.tofu
$ git commit -m'test'
OpenTofu fmt.........................................(no files to check)Skipped
OpenTofu validate....................................(no files to check)Skipped
OpenTofu validate with tflint........................(no files to check)Skipped
[main c5fa2ee] test
 1 file changed, 1 insertion(+)
```

Behaviour of this PR: 

```console 
$ git checkout support-tofu-files 
$ echo "#" >> hello.tofu 
$ git add hello.tofu
$ git commit -m'test'
OpenTofu fmt.............................................................Passed
OpenTofu validate........................................................Passed
OpenTofu validate with tflint............................................Failed
- hook id: tofu_tflint
- exit code: 2

Command 'tflint --init' successfully done:




TFLint in ./:
5 issue(s) found:

Warning: Missing version constraint for provider "null" in `required_providers` (terraform_required_providers)

  on hello.tf line 1:
   1: resource "null_resource" "hello_tf" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.9.1/docs/rules/terraform_required_providers.md

Warning: terraform "required_version" attribute is required (terraform_required_version)

  on hello.tf line 1:

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.9.1/docs/rules/terraform_required_version.md

Warning: Module should include a main.tf file as the primary entrypoint (terraform_standard_module_structure)

  on main.tf line 1:
   (source code not available)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.9.1/docs/rules/terraform_standard_module_structure.md

Warning: Module should include an empty outputs.tf file (terraform_standard_module_structure)

  on outputs.tf line 1:
   (source code not available)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.9.1/docs/rules/terraform_standard_module_structure.md

Warning: Module should include an empty variables.tf file (terraform_standard_module_structure)

  on variables.tf line 1:
   (source code not available)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.9.1/docs/rules/terraform_standard_module_structure.md
```