### PR TITLE
fix: Install newer tofu version to support new HCL syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache \
         setuptools
 
 ARG PRE_COMMIT_VERSION=${PRE_COMMIT_VERSION:-latest}
-ARG TOFU_VERSION=${TOFU_VERSION:-1.6.1}
+ARG TOFU_VERSION=${TOFU_VERSION:-1.9.0}
 
 # Install pre-commit
 RUN [ ${PRE_COMMIT_VERSION} = "latest" ] && pip3 install --no-cache-dir pre-commit \


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-opentofu!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

## Description of your changes

The current 1.6 that gets installed does not have the provider-defined functions feature, which has a new syntax. The new syntax causes `tofu fmt` fails on code that uses this feature.

Using the latest current release should fix this and possibly other issues.

Better solutions certainly exist, just trying to keep this simple.


<!-- Fixes # -->

## How can we test changes

Here's my test:

#### `main.tf`:
```hcl
terraform {
  required_providers {
    assert = {
      source = "hashicorp/assert"
    }
  }
}

variable "test" {
  type    = bool
  default = true
  validation {
    condition     = provider::assert::true(true)
    error_message = "Just a test."
  }
}
```

### 1.6 fails
```
tenv tofu use 1.6.1 && tofu -version && tofu fmt .
Written 1.6.1 in ~/.tenv/OpenTofu/version
OpenTofu v1.6.1
on darwin_amd64
╷
│ Error: Missing newline after argument
│
│   on main.tf line 13, in variable "test":
│   13:     condition     = provider::assert::true(true)
│
│ An argument definition must end with a newline.
╵
```

### 1.9 succeeds
```
tenv tofu use 1.9.0 && tofu -version && tofu fmt .
Written 1.9.0 in ~/.tenv/OpenTofu/version
OpenTofu v1.9.0
on darwin_arm64
<no output indicates success here>
```