### PR TITLE
fix: Update pre-commit/action version

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -40,7 +40,7 @@ jobs:
       with:
         python-version: '3.9'
     - name: Execute pre-commit
-      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      uses: pre-commit/action@576ff52938d158a24ac7e009dfa94b1455e7df99
       env:
         SKIP: no-commit-to-branch,hadolint
       with:
@@ -49,7 +49,7 @@ jobs:
     # Run only skipped checks
     - name: Execute pre-commit check that have no auto-fixes
       if: always()
-      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      uses: pre-commit/action@576ff52938d158a24ac7e009dfa94b1455e7df99
       env:
         SKIP: check-added-large-files,check-merge-conflict,check-vcs-permalinks,forbid-new-submodules,no-commit-to-branch,end-of-file-fixer,trailing-whitespace,check-yaml,check-merge-conflict,check-executables-have-shebangs,check-case-conflict,mixed-line-ending,detect-aws-credentials,detect-private-key,shfmt,shellcheck
       with:


### PR DESCRIPTION
This is needed to switch to the new cache:
https://gh.io/gha-cache-sunset

TODO: switch from pre-commit/action to the pre-commit.ci

<!--
Thank you for helping to improve pre-commit-opentofu!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.