### PR TITLE
fix: Replace deprecated hclfmt with hcl format command

### DIFF
--- a/hooks/terragrunt_fmt.sh
+++ b/hooks/terragrunt_fmt.sh
@@ -12,7 +12,7 @@ function main {
   common::parse_cmdline "$@"
   common::export_provided_env_vars "${ENV_VARS[@]}"
   common::parse_and_export_env_vars
-  # JFYI: terragrunt hclfmt color already suppressed via PRE_COMMIT_COLOR=never
+  # JFYI: terragrunt hcl format color already suppressed via PRE_COMMIT_COLOR=never
 
   # shellcheck disable=SC2153 # False positive
   common::per_dir_hook "$HOOK_ID" "${#ARGS[@]}" "${ARGS[@]}" "${FILES[@]}"
@@ -40,7 +40,7 @@ function per_dir_hook_unique_part {
   local -a -r args=("$@")
 
   # pass the arguments to hook
-  terragrunt hclfmt "${args[@]}"
+  terragrunt hcl format "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?
@@ -57,7 +57,7 @@ function run_hook_on_whole_repo {
   local -a -r args=("$@")
 
   # pass the arguments to hook
-  terragrunt hclfmt "$(pwd)" "${args[@]}"
+  terragrunt hcl format "$(pwd)" "${args[@]}"
 
   # return exit code to common::per_dir_hook
   local exit_code=$?


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Replace deprecated `terragrunt hclfmt` command with the recommended `terragrunt hcl format` to eliminate deprecation warnings.

Fixes #34


### How can we test changes

1. Create test directory with a `terragrunt.hcl` file
2. Add `.pre-commit-config.yaml`:
   ```yaml
   repos:
     - repo: https://github.com/tofuutils/pre-commit-opentofu
       rev: <this-branch>
       hooks:
         - id: terragrunt_fmt
   ```
3. Run: `pre-commit run terragrunt_fmt --all-files`

**Expected result:**
- No deprecation warning appears
- Files are formatted correctly
- Behavior identical to previous version

**Tested with:** Terragrunt v0.88.1