### PR TITLE
fix: Variable initialization

### DIFF
--- a/hooks/tofu_docs.sh
+++ b/hooks/tofu_docs.sh
@@ -69,6 +69,7 @@ function tofu_docs {
   local -a -r files=("$@")
 
   local -a paths
+  local config_file_no_color=""
 
   local index=0
   local file_with_path

--- a/hooks/tofu_docs_replace.py
+++ b/hooks/tofu_docs_replace.py
@@ -36,13 +36,14 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     dirs = []
+    seen_dirs = set()
     for filename in args.filenames:
-        if os.path.realpath(filename) not in dirs and (
-            filename.endswith(".tf")
-            or filename.endswith(".tofu")
-            or filename.endswith(".tfvars")
-        ):
-            dirs.append(os.path.dirname(filename))
+        if filename.endswith((".tf", ".tofu", ".tfvars")):
+            dir_path = os.path.dirname(filename)
+            dir_key = os.path.realpath(dir_path)
+            if dir_key not in seen_dirs:
+                seen_dirs.add(dir_key)
+                dirs.append(dir_path)
 
     retval = 0
 

--- a/hooks/tofu_validate.sh
+++ b/hooks/tofu_validate.sh
@@ -128,12 +128,18 @@ function per_dir_hook_unique_part {
 
   if [ "$retry_once_with_cleanup" != "true" ]; then
     # tofu validate only
-    validate_output=$(tofu validate "${args[@]}" 2>&1)
-    exit_code=$?
+    if validate_output=$(tofu validate "${args[@]}" 2>&1); then
+      exit_code=0
+    else
+      exit_code=$?
+    fi
   else
     # tofu validate, plus capture possible errors
-    validate_output=$(tofu validate -json "${args[@]}" 2>&1)
-    exit_code=$?
+    if validate_output=$(tofu validate -json "${args[@]}" 2>&1); then
+      exit_code=0
+    else
+      exit_code=$?
+    fi
 
     # Match specific validation errors
     local -i validate_errors_matched
@@ -155,8 +161,11 @@ function per_dir_hook_unique_part {
         return $exit_code
       }
 
-      validate_output=$(tofu validate "${args[@]}" 2>&1)
-      exit_code=$?
+      if validate_output=$(tofu validate "${args[@]}" 2>&1); then
+        exit_code=0
+      else
+        exit_code=$?
+      fi
     fi
   fi
 


### PR DESCRIPTION
<!--
Thank you for helping to improve pre-commit-opentofu!
-->

Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [x] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Fixes two small hook bugs:

- `tofu_validate.sh` now captures failed `tofu validate` output and exit codes correctly when `set -e` is enabled.
- `tofu_docs_replace.py` now de-duplicates Terraform/OpenTofu directories using normalized directory paths instead of comparing file paths against directory entries.

<!-- Fixes # -->

### How can we test changes

Tested with:

```text
bash -n hooks/tofu_validate.sh
python3 -m py_compile hooks/tofu_docs_replace.py
```

No Terraform/OpenTofu commands were run.
