### PR TITLE
fix(hooks): Make env var regex portable

### DIFF
--- a/hooks/_common.sh
+++ b/hooks/_common.sh
@@ -112,7 +112,7 @@ function common::parse_and_export_env_vars {
     while true; do
       # Check if at least 1 env var exists in `$arg`
       # shellcheck disable=SC2016 # '${' should not be expanded
-      if [[ "$arg" =~ .*'${'[A-Z_][A-Z0-9_]*'}'.* ]]; then
+      if [[ "$arg" =~ '${'[A-Z_][A-Za-z0-9_]*'}' ]]; then
         # Get `ENV_VAR` from `.*${ENV_VAR}.*`
         local env_var_name=${arg#*$\{}
         env_var_name=${env_var_name%%\}*}


### PR DESCRIPTION
Put an `x` into the box if that apply:

- [ ] This PR introduces breaking change.
- [X] This PR fixes a bug.
- [ ] This PR adds new functionality.
- [ ] This PR enhances existing functionality.

### Description of your changes

Adjust the regex used to detect `${ENV_VAR}` patterns in `hooks/_common.sh` to avoid Bash-incompatible constructs and to be compatible with macOS/BSD regex behavior.

- Remove unnecessary leading/trailing '.*' since =~ matches substrings.
- Allow lowercase letters in subsequent identifier characters ([A-Za-z0-9_]) so variable names with lowercase chars are detected.
- Keep first-char restriction to uppercase or underscore to match existing extraction logic.

---

- Closes #55 